### PR TITLE
restart sbml4j on-failure

### DIFF
--- a/dockercompose/docker-compose.yaml
+++ b/dockercompose/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
         volumes:
             - sbml4j_network_db:/db
             - ./database_backups:/database_backups
-        command: ["/bin/sh", "-c", "cd /db && tar xfz /database_backups/sbml4j_pecax_0.0.32.tar.gz --strip 1"] 
+        command: ["/bin/sh", "-c", "cd /db && tar xfz /database_backups/sbml4j_pecax_0.0.32.tar.gz --strip 1"]
     db_backup:
         image: alpine
         volumes:
@@ -133,7 +133,7 @@ services:
             - "sbml4jdatabase"
         ports:
             - "8080:8080"
-        restart: unless-stopped
+        restart: on-failure
 volumes:
     clinvap_uploads:
     clinvap_downloads:


### PR DESCRIPTION
MInor change in the runtime behaviour of sbml4j. This way it restarts when the database is too slow on startup. The only downside to that is, that the restarted container does not get attached to the current console.