### PR TITLE
Revert and fix to neo4j:4.1 for now

### DIFF
--- a/dockercompose/docker-compose.yaml
+++ b/dockercompose/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
             - ./neo4j/plugins:/plugins
         command: ["/bin/sh", "-c", "cd /plugins && wget https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/4.1.0.2/apoc-4.1.0.2-all.jar"]
     sbml4jdatabase:
-        image: neo4j
+        image: neo4j:4.1
         container_name: sbml4jdb
         volumes:
             - sbml4j_network_db:/var/lib/neo4j/data
@@ -98,7 +98,7 @@ services:
             - NEO4J_dbms_memory_heap_initial__size=2G
             - NEO4J_dbms_memory_heap_max__size=2G
             - NEO4J_dbms_security_procedures_unrestricted=apoc.algo.dijkstraWithDefaultWeight, apoc.path.expand
-            - NEO4J_dbms_security_procedures_allowlist=apoc.algo.dijkstraWithDefaultWeight, apoc.path.expand
+            - NEO4J_dbms_security_procedures_whitelist=apoc.algo.dijkstraWithDefaultWeight, apoc.path.expand
         restart: unless-stopped
         command: ["neo4j"]
     sbml4j:


### PR DESCRIPTION
Unfortunately it came to light the the database created in 4.1 would not load in 4.2 and thus the jump to 4.2 is not done as easily as hoped. 
So for now I would like to freeze the used neo4j version at 4.1 to guarantee working networks for the time being.
When a new database has been loaded with neo4j:4.2 I will update this again.